### PR TITLE
Fix sorting using dicts, by doing reversed({"key": -1}) we get -> ["k…

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1062,6 +1062,8 @@ class Collection(object):
     def _get_dataset(self, spec, sort, fields, as_class):
         dataset = self._iter_documents(spec)
         if sort:
+            if isinstance(sort, dict):
+                sort = sort.items()
             for sort_key, sort_direction in reversed(sort):
                 if sort_key == '$natural':
                     if sort_direction < 0:

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -635,6 +635,30 @@ class CollectionAPITest(TestCase):
         doc.pop('_id')
         self.assertDictEqual(doc, replacement)
 
+    def test__find_one_sorting(self):
+        documents = [
+            {'x': 1, 's': 0},
+            {'x': 1, 's': 1},
+            {'x': 4, 's': 1},
+            {'x': 1, 's': 2},
+            {'x': 1, 's': 3},
+            {'x': 9, 's': 1}
+        ]
+        self.db.collection.insert_many(documents)
+        self.assert_documents(documents, ignore_ids=False)
+
+        doc = self.db.collection.find_one(
+            {'x': 1}, sort={'x': -1}
+        )
+
+        self.assertDictEqual(doc, documents[-2])
+
+        doc = self.db.collection.find_one(
+            {'x': 1}, sort={'x': 1}
+        )
+
+        self.assertDictEqual(doc, documents[0])
+
     def test__find_one_and_update(self):
         documents = [
             {'x': 1, 's': 0},


### PR DESCRIPTION
…ey"], failing to unwrap the sorting direction.